### PR TITLE
Partition Cloudfront Logs by the hour as well as year, month, day

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,4 +87,4 @@ clean_glue: require_service
 	aws s3 rm --recursive $(S3_CONVERTED_TARGET)
 
 test:
-	python -m pytest test
+	python -m pytest -vv test

--- a/athena_glue_service_logs/catalog_manager.py
+++ b/athena_glue_service_logs/catalog_manager.py
@@ -63,7 +63,7 @@ class BaseCatalogManager(metaclass=abc.ABCMeta):
         self.get_and_create_partitions()
 
     def create_table(self):
-        """Create this database talbe in the Data Catalog"""
+        """Create this database table in the Data Catalog"""
         LOGGER.info("Creating database table %s", self.table_name)
         self.glue_client.create_table(
             DatabaseName=self.database_name,

--- a/athena_glue_service_logs/cloudfront.py
+++ b/athena_glue_service_logs/cloudfront.py
@@ -19,7 +19,7 @@ https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.ht
 import logging
 
 from athena_glue_service_logs.catalog_manager import BaseCatalogManager
-from athena_glue_service_logs.partitioners.date_partitioner import DatePartitioner
+from athena_glue_service_logs.partitioners.datetime_partitioner import DateTimePartitioner
 from athena_glue_service_logs.partitioners.null_partitioner import NullPartitioner
 
 
@@ -96,7 +96,7 @@ class CloudFrontConvertedCatalog(BaseCatalogManager):
         return "time"
 
     def get_partitioner(self):
-        return DatePartitioner(s3_location=self.s3_location, hive_compatible=True)
+        return DateTimePartitioner(s3_location=self.s3_location, hive_compatible=True)
 
     def _build_storage_descriptor(self, partition_values=None):
         if partition_values is None:

--- a/athena_glue_service_logs/partitioners/base_partitioner.py
+++ b/athena_glue_service_logs/partitioners/base_partitioner.py
@@ -61,6 +61,24 @@ class BasePartitioner(metaclass=abc.ABCMeta):
 
         return partitions
 
+    def _get_datetime_values_since_initial_time(self, datetime_tuple):
+        """Takes an initial datetime tuple and returns a computed set of datetime tuples until UTC now
+
+        Does _not_ include the original datetime tuple.
+        """
+        partitions = []
+        datetime_ints = list(map(int, datetime_tuple))
+        initial_time = datetime(*datetime_ints)
+        now = datetime.utcfromtimestamp(time.time())
+
+        diff = now-initial_time
+        for i in range((diff.days * 86400 + diff.seconds) // 3600):
+            new_time = initial_time + timedelta(hours=i+1)
+            part = new_time.strftime('%Y-%m-%d-%H').split('-')
+            partitions.append(part)
+
+        return partitions
+
     def build_partitioned_path(self, partition_values):
         """Takes a tuple of partition values and returns the S3 URI for that specific partition."""
         base_path = self.s3_location.rstrip('/')

--- a/athena_glue_service_logs/partitioners/datetime_partitioner.py
+++ b/athena_glue_service_logs/partitioners/datetime_partitioner.py
@@ -1,0 +1,69 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# or in the "license" file accompanying this file. This file is distributed 
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
+# express or implied. See the License for the specific language governing 
+# permissions and limitations under the License.
+
+"""DateTimePartioner is an implementation of a Partioner where data is structured in S3 in a Y/m/d/hh format"""
+import time
+from datetime import datetime, timedelta
+
+from athena_glue_service_logs.partitioners.base_partitioner import BasePartitioner
+from athena_glue_service_logs.utils import S3Reader
+
+
+class DateTimePartitioner(BasePartitioner):
+    """DatePartioner is an implementation of a Partioner where data is structured in S3 in a Y/m/d/hh format"""
+    MAX_RECENT_HOURS = 72
+
+    def build_partitions_from_s3(self):
+        partition_values = []
+        s3_reader = S3Reader(self.s3_location)
+
+        # Get first date and add to data catalog
+        # Then add all partitions after that date
+        if self.hive_compatible:
+            key_names = [key['Name'] for key in self.partition_keys()]
+            first_partition = s3_reader.get_first_hivecompatible_datetime_in_prefix(key_names)
+        else:
+            first_partition = s3_reader.get_first_datetime_in_prefix()
+        partition_values.append(first_partition)
+        partition_values += self._get_datetime_values_since_initial_time(first_partition)
+
+        return partition_values
+
+    def partition_keys(self):
+        return [
+            {"Name": "year", "Type": "string"},
+            {"Name": "month", "Type": "string"},
+            {"Name": "day", "Type": "string"},
+            {"Name": "hour", "Type": "string"},
+        ]
+
+    def find_recent_partitions(self, existing_partitions):
+        partitions_to_add = []
+
+        # Now check to see if, in each region, that a partition day exists for today.
+        # If it does not, backfill up to today.
+        now = datetime.utcfromtimestamp(time.time())
+        hour_diff = 0
+
+        # Only go back MAX_RECENT_HOURS hours for now and only if S3 objects actually exist...
+        for _ in range(self.MAX_RECENT_HOURS):
+            new_hour = now + timedelta(hours=hour_diff)
+            new_hour_tuple = new_hour.strftime('%Y-%m-%d-%H').split('-')
+            if not existing_partitions or existing_partitions[-1] != new_hour_tuple:
+                if S3Reader(self.build_partitioned_path(new_hour_tuple)).does_have_objects():
+                    partitions_to_add.append(new_hour_tuple)
+            else:
+                break
+            hour_diff -= 1
+
+        return partitions_to_add

--- a/test/partitioners/test_base_partitioner.py
+++ b/test/partitioners/test_base_partitioner.py
@@ -28,6 +28,18 @@ def test_date_generator(mocker):
     assert new_tuples[-1] == today.__str__().split('-')
 
 
+def test_datetime_generator(mocker):
+    mocker.patch.multiple(BasePartitioner, __abstractmethods__=set())
+    base_part = BasePartitioner(s3_location="s3://nowhere")
+    now = datetime.utcfromtimestamp(time.time())
+
+    datetime_tuple = ['2020', '06', '24', '12']
+    new_tuples = base_part._get_datetime_values_since_initial_time(datetime_tuple)
+
+    assert new_tuples[0] == ['2020', '06', '24', '13']
+    assert new_tuples[-1] == now.strftime('%Y-%m-%d-%H').split('-')
+
+
 def test_nonhive_partitioned_path(mocker):
     mocker.patch.multiple(BasePartitioner, __abstractmethods__=set())
     base_part = BasePartitioner(s3_location="s3://nowhere")

--- a/test/partitioners/test_datetime_partitioner.py
+++ b/test/partitioners/test_datetime_partitioner.py
@@ -1,0 +1,146 @@
+# pylint: skip-file
+import time
+from datetime import datetime, timedelta
+
+from athena_glue_service_logs.partitioners.datetime_partitioner import DateTimePartitioner
+
+from utils import S3Stubber
+
+
+def now():
+    return datetime.utcfromtimestamp(time.time())
+
+
+def last_hour():
+    return datetime.utcfromtimestamp(time.time()) - timedelta(hours=1)
+
+
+def basic_s3_key():
+    return {
+        'Key': '/2020/06/11/18/some_data.json.gz',  # '/2020/06/11/18/some_data.json.gz'
+        'LastModified': datetime(2020, 6, 23, hour=5),
+        'ETag': 'string',
+        'Size': 123,
+        'StorageClass': 'STANDARD',
+        'Owner': {
+            'DisplayName': 'string',
+            'ID': 'string'
+        }
+    }
+
+
+def request_params():
+    return {'Bucket': 'nowhere', 'MaxKeys': 10, 'Prefix': '/'}
+
+
+def today_objects():
+    return [
+        {
+            'Key': '/%s/some_data.json.gz' % now().strftime("%Y/%m/%d/%H"),
+            'LastModified': datetime(2020, 6, 23, hour=17),
+            'ETag': 'string',
+            'Size': 123,
+            'StorageClass': 'STANDARD',
+            'Owner': {
+                'DisplayName': 'string',
+                'ID': 'string'
+            }
+        },
+        {
+            'Key': '/%s/more_data.json.gz' % now().strftime("%Y/%m/%d/%H"),
+            'LastModified': datetime(2020, 6, 23, hour=18),
+            'ETag': 'string',
+            'Size': 123,
+            'StorageClass': 'STANDARD',
+            'Owner': {
+                'DisplayName': 'string',
+                'ID': 'string'
+            }
+        }
+    ]
+
+
+def yesterday_objects():
+        return [
+            {
+                'Key': '/%s/some_data.json.gz' % last_hour().strftime("%Y/%m/%d/%H"),
+                'LastModified': datetime(2020, 6, 22, hour=17),
+                'ETag': 'string',
+                'Size': 123,
+                'StorageClass': 'STANDARD',
+                'Owner': {
+                    'DisplayName': 'string',
+                    'ID': 'string'
+                }
+            }
+        ]
+
+
+def list_request_for_ts(timestamp):
+    return {'Bucket': 'nowhere', 'MaxKeys': 10, 'Prefix': timestamp.strftime("%Y/%m/%d/%H")}
+
+
+def today_objects_request():
+    return {'Bucket': 'nowhere', 'MaxKeys': 10, 'Prefix': now().strftime("%Y/%m/%d/%H")}
+
+
+def test_partition_scanner(mocker):
+    datetime_part = DateTimePartitioner(s3_location="s3://nowhere")
+    now = datetime.utcfromtimestamp(time.time())
+
+    s3_stub = S3Stubber.for_single_request('list_objects_v2', request_params(), [basic_s3_key()])
+    with mocker.patch('boto3.client', return_value=s3_stub.client):
+        with s3_stub.stubber:
+            new_tuples = datetime_part.build_partitions_from_s3()
+
+    assert new_tuples[0] == ['2020', '06', '11', '18']
+    assert new_tuples[-1] == now.strftime('%Y-%m-%d-%H').split('-')
+
+
+def test_partition_builder():
+    datetime_part = DateTimePartitioner(s3_location="s3://nowhere")
+    response = datetime_part.build_partitioned_path(['2017', '08', '11', '19'])
+
+    assert response == 's3://nowhere/2017/08/11/19'
+
+
+def test_partition_key_order():
+    """Partition keys should be returned in order"""
+    datetime_part = DateTimePartitioner(s3_location="s3://nowhere")
+    key_names = [x['Name'] for x in datetime_part.partition_keys()]
+    assert key_names == ['year', 'month', 'day', 'hour']
+
+
+def test_find_new_partitions(mocker):
+    datetime_part = DateTimePartitioner(s3_location="s3://nowhere")
+    existing_part = last_hour().strftime('%Y-%m-%d-%H').split('-')
+
+    s3_stub = S3Stubber.for_single_request('list_objects_v2', today_objects_request(), today_objects())
+    with mocker.patch('boto3.client', return_value=s3_stub.client):
+        with s3_stub.stubber:
+            new_partitions = datetime_part.find_recent_partitions([existing_part])
+
+    assert len(new_partitions) == 1
+    assert new_partitions == [now().strftime('%Y-%m-%d-%H').split('-')]
+
+
+def test_find_all_new_partitions(mocker):
+    datetime_part = DateTimePartitioner(s3_location="s3://nowhere")
+
+    requests = []
+    # Create request parameters for every day since (and including) today
+    for i in range(DateTimePartitioner.MAX_RECENT_HOURS):
+        requests.append(list_request_for_ts(now() - timedelta(hours=i)))
+
+    s3_stub = S3Stubber.for_multiple_requests(
+        'list_objects_v2',
+        requests,
+        [today_objects(), yesterday_objects()] + [[]]*(DateTimePartitioner.MAX_RECENT_HOURS-2)
+    )
+    with mocker.patch('boto3.client', return_value=s3_stub.client):
+        with s3_stub.stubber:
+            new_partitions = datetime_part.find_recent_partitions([])
+
+    # Only 2 hours have data
+    assert len(new_partitions) == 2
+    assert new_partitions == [now().strftime('%Y-%m-%d-%H').split('-'), last_hour().strftime('%Y-%m-%d-%H').split('-')]

--- a/test/test_cloudfront.py
+++ b/test/test_cloudfront.py
@@ -1,0 +1,139 @@
+# pylint: skip-file
+import pytest
+from datetime import datetime, timedelta
+from random import choice, randrange
+
+from athena_glue_service_logs.cloudfront import CloudFrontRawCatalog, CloudFrontConvertedCatalog
+from utils import GlueStubber
+
+
+@pytest.fixture(scope="module")
+def raw_catalog():
+    return CloudFrontRawCatalog(
+        region='us-west-2',
+        database_name='raw',
+        table_name='cf_logs',
+        s3_location='s3://source-bucket/raw-cf-logs'
+    )
+
+
+@pytest.fixture(scope="module")
+def converted_catalog():
+    return CloudFrontConvertedCatalog(
+        region='us-west-2',
+        database_name='clean',
+        table_name='cf_logs',
+        s3_location='s3://target-bucket/clean-cf-logs'
+    )
+
+
+def test_converted_build_partitioned_path(converted_catalog):
+    """Converted catalog will have hive-compatible partitions"""
+    part_values = ['2017', '12', '16', '22']
+    path = converted_catalog.partitioner.build_partitioned_path(part_values)
+
+    assert path == 's3://target-bucket/clean-cf-logs/year=2017/month=12/day=16/hour=22'
+
+
+def test_raw_build_partitioned_path(raw_catalog):
+    """Raw catalog will not have hive-compatible partitions"""
+    part_values = []
+    path = raw_catalog.partitioner.build_partitioned_path(part_values)
+
+    assert path == 's3://source-bucket/raw-cf-logs'
+
+
+def test_storage_descriptor_with_no_partitions(raw_catalog, converted_catalog):
+    descriptor = raw_catalog._build_storage_descriptor()
+    assert 'Columns' in descriptor
+    assert descriptor['Location'] == 's3://source-bucket/raw-cf-logs'
+
+    descriptor = converted_catalog._build_storage_descriptor()
+    assert 'Columns' in descriptor
+    assert descriptor['Location'] == 's3://target-bucket/clean-cf-logs'
+
+
+def test_storage_descriptor_with_partitions(raw_catalog, converted_catalog):
+    descriptor = raw_catalog._build_storage_descriptor([])
+    assert 'Columns' in descriptor
+    assert descriptor['Location'] == 's3://source-bucket/raw-cf-logs'
+
+    descriptor = converted_catalog._build_storage_descriptor(['2017', '12', '25', '23'])
+    assert 'Columns' in descriptor
+    assert descriptor['Location'] == 's3://target-bucket/clean-cf-logs/year=2017/month=12/day=25/hour=23'
+
+
+def test_timestamp_field(raw_catalog, converted_catalog):
+    assert raw_catalog.timestamp_field() == 'time'
+    assert converted_catalog.timestamp_field() == 'time'
+
+
+def test_table_params(raw_catalog):
+    """CloudFront also has custom table parameters it needs for Glue compatibility"""
+    assert raw_catalog._table_parameters()['skip.header.line.count'] == '2'
+
+    # Let's try with the full table_input as well
+    table_input = raw_catalog._build_table_input()
+    assert 'skip.header.line.count' in table_input['Parameters']
+
+def test_partition_pagination(raw_catalog, mocker):
+    """Tests that we properly find new partitions when partition count exceeds what is returned by Glue API call"""
+    params = {'DatabaseName': 'dcortesi', 'TableName': 'partest'}
+    single_glue_stub = GlueStubber()
+    single_glue_stub.add_response_for_method('get_partitions', build_glue_response(num=5), params)
+
+    multi_glue_stub = GlueStubber()
+    token = 'deadbeef=='
+    multi_glue_stub.add_response_for_method('get_partitions', build_glue_response(num=5, next_token=token), params)
+    next_params = params.copy()
+    next_params['NextToken'] = token
+    multi_glue_stub.add_response_for_method('get_partitions', build_glue_response(num=7), next_params)
+
+    # First just make sure the get_partition_values method works
+    with mocker.patch('boto3.client', return_value=single_glue_stub.client):
+        with single_glue_stub.stubber:
+            c = CloudFrontRawCatalog('us-west-2', params.get('DatabaseName'), params.get('TableName'), 's3://blah')
+            resp = c.get_partition_values()
+            assert len(resp) == 5
+
+    # Next make sure that when there are multiple partition results, we get them all
+    with mocker.patch('boto3.client', return_value=multi_glue_stub.client):
+        with multi_glue_stub.stubber:
+            c = CloudFrontRawCatalog('us-west-2', params.get('DatabaseName'), params.get('TableName'), 's3://blah')
+            resp = c.get_partition_values()
+            assert len(resp) == 12
+
+
+def build_glue_response(num, next_token=None):
+    """Helper to programatically create a Glue API response"""
+    available_regions = [
+        'ap-northeast-1',
+        'ap-northeast-2',
+        'ap-northeast-3',
+        'ap-south-1',
+        'ap-southeast-1',
+        'ap-southeast-2',
+        'ca-central-1',
+        'eu-central-1',
+        'eu-north-1',
+        'eu-west-1',
+        'eu-west-2',
+        'eu-west-3',
+        'sa-east-1',
+        'us-east-1',
+        'us-east-2',
+        'us-west-1',
+        'us-west-2'
+    ]
+    response = {'Partitions': []}
+    if next_token is not None:
+        response['NextToken'] = next_token
+    start_date = datetime.utcnow().date()
+    part_date = start_date
+
+    for i in range(num):
+        part = [choice(available_regions)] + part_date.strftime("%Y-%m-%d-%H").split("-")
+        part_date = part_date + timedelta(days=-randrange(30))
+        response['Partitions'].append({'Values': part})
+
+    return response


### PR DESCRIPTION
CloudFront log are high volume (for us) and so we need to partition them by the hour, at the very least.